### PR TITLE
fix memory leak in TdGOpf.Create

### DIFF
--- a/core/dopf.pas
+++ b/core/dopf.pas
@@ -1755,6 +1755,7 @@ end;
 
 destructor TdGOpf.Destroy;
 begin
+  FQuery.Free;
   FreeTable;
   inherited Destroy;
 end;


### PR DESCRIPTION
In TdGOpf.Create FQuery is created but never destroyed. Call
FQuery.Free.